### PR TITLE
Update security_fr.md

### DIFF
--- a/security_fr.md
+++ b/security_fr.md
@@ -81,7 +81,7 @@ Ensuite redémarrez le firewall iptables et fermez l’ancien port dans iptables
 ```bash
 yunohost firewall reload
 yunohost firewall disallow <votre numéro de port> # port par défaut 22
-yunohost firewall disallow --ipv6 <votre numéro de port> # pour ipv6
+yunohost firewall disallow --ipv6 TCP <votre numéro de port> # pour ipv6
 ``` 
 
 **Pour les prochaines connexions SSH** il faudra ajouter l’option -p suivie du numéro de port SSH.


### PR DESCRIPTION
(Sur une install "fraiche")
Si l'on omet l'argument <TCP>, on obtient ce message d'erreur :

 "usage: yunohost firewall disallow [-h] [--upnp-only] [--no-reload] [-6] [-4]
                                  {TCP,UDP,Both} port
yunohost firewall disallow: error: argument protocol: invalid choice: '22' (choose from 'TCP', 'UDP', 'Both')
"
